### PR TITLE
API GatewayにCORSを設定

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -1,6 +1,9 @@
 resource "aws_apigatewayv2_api" "tetris_api" {
   name          = var.api_gateway_name
   protocol_type = "HTTP"
+  cors_configuration {
+    allow_origins = var.api_gateway_allow_origins
+  }
 }
 
 resource "aws_apigatewayv2_stage" "tetris_api_stage" {

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -4,6 +4,7 @@ API Gateway
 api_gateway_name              = "tetris_api"
 api_gateway_stage_name        = "tetris_api_stage"
 api_gateway_access_log_format = "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId"
+api_gateway_allow_origins     = ["https://d1ya9tc3wcnkn0.cloudfront.net"]
 
 /* 
 Lambda

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,6 +4,7 @@ API Gateway
 variable "api_gateway_name" {}
 variable "api_gateway_stage_name" {}
 variable "api_gateway_access_log_format" {}
+variable "api_gateway_allow_origins" {}
 
 /* 
 Lambda


### PR DESCRIPTION
https://github.com/seigot/tetris_score_server_frontend/issues/15
frontendからapi gatewayへリクエストを送った時にCORSでエラーが出る。
これはapi gateway側でfrontend側のoriginを許可していないからなので、許可する設定を追加する