### PR TITLE
スコア評価用のECSタスク数をオートスケールさせる

### DIFF
--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -49,20 +49,10 @@ resource "aws_cloudwatch_metric_alarm" "sqs_waiting_message_alarm" {
   }
 
   alarm_description = "This metric monitors sqs message counts"
-}
-
-resource "aws_cloudwatch_metric_alarm" "sqs_no_message_alarm" {
-  alarm_name          = var.cloudwatch_ecs_scalein_alarm
-  comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "ApproximateNumberOfMessagesNotVisible"
-  namespace           = "AWS/SQS"
-  period              = "60"
-  statistic           = "Sum"
-  threshold           = "1"
-  dimensions = {
-    QueueName  = aws_sqs_queue.score_evaluation_queue.name
-  }
-
-  alarm_description = "This metric monitors sqs being processed message counts"
+  alarm_actions = [
+    aws_appautoscaling_policy.ecs_score_evaluation_scaleout_policy.arn,
+  ]
+  ok_actions = [
+    aws_appautoscaling_policy.ecs_score_evaluation_scalein_policy.arn,
+  ]
 }

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -34,3 +34,19 @@ resource "aws_cloudwatch_log_group" "apigateway_accesslog" {
 resource "aws_cloudwatch_log_group" "ecs_execution_log" {
   name = var.cloudwatch_ecs_log_group_name
 }
+
+resource "aws_cloudwatch_metric_alarm" "sqs_message_count_alarm" {
+  alarm_name          = var.cloudwatch_ecs_scaling_alarm
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+  dimensions = {
+    QueueName  = aws_sqs_queue.score_evaluation_queue.name
+  }
+
+  alarm_description = "This metric monitors sqs message counts"
+}

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -35,8 +35,8 @@ resource "aws_cloudwatch_log_group" "ecs_execution_log" {
   name = var.cloudwatch_ecs_log_group_name
 }
 
-resource "aws_cloudwatch_metric_alarm" "sqs_message_count_alarm" {
-  alarm_name          = var.cloudwatch_ecs_scaling_alarm
+resource "aws_cloudwatch_metric_alarm" "sqs_waiting_message_alarm" {
+  alarm_name          = var.cloudwatch_ecs_scaleout_alarm
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -49,4 +49,20 @@ resource "aws_cloudwatch_metric_alarm" "sqs_message_count_alarm" {
   }
 
   alarm_description = "This metric monitors sqs message counts"
+}
+
+resource "aws_cloudwatch_metric_alarm" "sqs_no_message_alarm" {
+  alarm_name          = var.cloudwatch_ecs_scalein_alarm
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ApproximateNumberOfMessagesNotVisible"
+  namespace           = "AWS/SQS"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+  dimensions = {
+    QueueName  = aws_sqs_queue.score_evaluation_queue.name
+  }
+
+  alarm_description = "This metric monitors sqs being processed message counts"
 }

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -36,7 +36,7 @@ cloudwatch_role_api_gateway_putlog    = "cloudwatch_role_api_gateway_putlog"
 cloudwatch_api_gateway_log_group_name = "tetris_apigateway_accesslog"
 cloudwatch_ecs_log_group_name         = "score_evaluation_ecs_log"
 cloudwatch_ecs_scaleout_alarm         = "sqs_waiting_message_alarm"
-cloudwatch_ecs_scalein_alarm          = "sqs_no_message_alarm"
+cloudwatch_ecs_scalein_alarm          = "sqs_no_being processed_message_alarm"
 
 /* 
 SQS

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -35,6 +35,7 @@ CloudWatch
 cloudwatch_role_api_gateway_putlog    = "cloudwatch_role_api_gateway_putlog"
 cloudwatch_api_gateway_log_group_name = "tetris_apigateway_accesslog"
 cloudwatch_ecs_log_group_name         = "score_evaluation_ecs_log"
+cloudwatch_ecs_scaling_alarm          = "sqs_message_count_alarm"
 
 /* 
 SQS

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -35,7 +35,8 @@ CloudWatch
 cloudwatch_role_api_gateway_putlog    = "cloudwatch_role_api_gateway_putlog"
 cloudwatch_api_gateway_log_group_name = "tetris_apigateway_accesslog"
 cloudwatch_ecs_log_group_name         = "score_evaluation_ecs_log"
-cloudwatch_ecs_scaling_alarm          = "sqs_message_count_alarm"
+cloudwatch_ecs_scaleout_alarm         = "sqs_waiting_message_alarm"
+cloudwatch_ecs_scalein_alarm          = "sqs_no_message_alarm"
 
 /* 
 SQS

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,6 +35,7 @@ CloudWatch
 variable "cloudwatch_role_api_gateway_putlog" {}
 variable "cloudwatch_api_gateway_log_group_name" {}
 variable "cloudwatch_ecs_log_group_name" {}
+variable "cloudwatch_ecs_scaling_alarm" {}
 
 /* 
 SQS

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,7 +35,8 @@ CloudWatch
 variable "cloudwatch_role_api_gateway_putlog" {}
 variable "cloudwatch_api_gateway_log_group_name" {}
 variable "cloudwatch_ecs_log_group_name" {}
-variable "cloudwatch_ecs_scaling_alarm" {}
+variable "cloudwatch_ecs_scaleout_alarm" {}
+variable "cloudwatch_ecs_scalein_alarm" {}
 
 /* 
 SQS


### PR DESCRIPTION
sqsに保存されているメッセージの数を判定基準として、
メッセージが1以上ある場合には
　cloudwatch alarmをalarm状態　→　desired task 数を1に設定
メッセージが0この場合には
　cloudwatch alarmをok状態　 　→　desired task 数を0に設定

で実現している
