### PR TITLE
ECS本番環境で動作しない部分を修正

### DIFF
--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -31,5 +31,5 @@ jobs:
         working-directory: ./terraform/environments/prod
 
       - name: Terraform plan
-        run: terraform plan -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_PROD }} -var score_evaluation_container_image=${{ secrets.TETRIS_ECR_REPOSITORY_PROD }}
+        run: terraform plan -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_PROD }} -var tetris_ecr_repository=${{ secrets.TETRIS_ECR_REPOSITORY_PROD }}
         working-directory: ./terraform/environments/prod

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -31,5 +31,5 @@ jobs:
         working-directory: ./terraform/environments/prod
 
       - name: Terraform plan
-        run: terraform plan -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_PROD }}
+        run: terraform plan -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_PROD }} -var score_evaluation_container_image=${{ secrets.TETRIS_ECR_REPOSITORY_PROD }}
         working-directory: ./terraform/environments/prod

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -30,6 +30,14 @@ jobs:
         run: terraform init
         working-directory: ./terraform/environments/prod
 
+      - name: Pip install for lambda layer 1
+        run: make
+        working-directory: ./scripts/api_to_dynamodb_lambda/layer
+
+      - name: Pip install for lambda layer 2
+        run: make
+        working-directory: ./scripts/api_to_sqs_lambda/layer
+        
       - name: Terraform plan
         run: terraform plan -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_PROD }} -var tetris_ecr_repository=${{ secrets.TETRIS_ECR_REPOSITORY_PROD }}
         working-directory: ./terraform/environments/prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
         working-directory: ./terraform/environments/dev
 
       - name: Terraform plan
-        run: terraform plan -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_DEV }} -var score_evaluation_container_image=${{ secrets.TETRIS_ECR_REPOSITORY_DEV }}
+        run: terraform plan -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_DEV }} -var tetris_ecr_repository=${{ secrets.TETRIS_ECR_REPOSITORY_DEV }}
         working-directory: ./terraform/environments/dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
         working-directory: ./terraform/environments/dev
 
       - name: Terraform plan
-        run: terraform plan -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_DEV }}
+        run: terraform plan -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_DEV }} -var score_evaluation_container_image=${{ secrets.TETRIS_ECR_REPOSITORY_DEV }}
         working-directory: ./terraform/environments/dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,14 @@ jobs:
         run: terraform init
         working-directory: ./terraform/environments/dev
 
+      - name: Pip install for lambda layer 1
+        run: make
+        working-directory: ./scripts/api_to_dynamodb_lambda/layer
+
+      - name: Pip install for lambda layer 2
+        run: make
+        working-directory: ./scripts/api_to_sqs_lambda/layer
+
       - name: Terraform plan
         run: terraform plan -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_DEV }} -var tetris_ecr_repository=${{ secrets.TETRIS_ECR_REPOSITORY_DEV }}
         working-directory: ./terraform/environments/dev

--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -31,5 +31,5 @@ jobs:
         working-directory: ./terraform/environments/prod
 
       - name: Terraform apply
-        run: terraform apply -auto-approve -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_PROD }}
+        run: terraform apply -auto-approve -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_PROD }} -var score_evaluation_container_image=${{ secrets.TETRIS_ECR_REPOSITORY_PROD }}
         working-directory: ./terraform/environments/prod

--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -31,5 +31,5 @@ jobs:
         working-directory: ./terraform/environments/prod
 
       - name: Terraform apply
-        run: terraform apply -auto-approve -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_PROD }} -var score_evaluation_container_image=${{ secrets.TETRIS_ECR_REPOSITORY_PROD }}
+        run: terraform apply -auto-approve -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_PROD }} -var tetris_ecr_repository=${{ secrets.TETRIS_ECR_REPOSITORY_PROD }}
         working-directory: ./terraform/environments/prod

--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -29,6 +29,14 @@ jobs:
       - name: Terraform Init
         run: terraform init
         working-directory: ./terraform/environments/prod
+      
+      - name: Pip install for lambda layer 1
+        run: make
+        working-directory: ./scripts/api_to_dynamodb_lambda/layer
+
+      - name: Pip install for lambda layer 2
+        run: make
+        working-directory: ./scripts/api_to_sqs_lambda/layer
 
       - name: Terraform apply
         run: terraform apply -auto-approve -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_PROD }} -var tetris_ecr_repository=${{ secrets.TETRIS_ECR_REPOSITORY_PROD }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -31,5 +31,5 @@ jobs:
         working-directory: ./terraform/environments/dev
 
       - name: Terraform apply
-        run: terraform apply -auto-approve -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_DEV }}
+        run: terraform apply -auto-approve -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_DEV }} -var score_evaluation_container_image=${{ secrets.TETRIS_ECR_REPOSITORY_DEV }}
         working-directory: ./terraform/environments/dev

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -31,5 +31,5 @@ jobs:
         working-directory: ./terraform/environments/dev
 
       - name: Terraform apply
-        run: terraform apply -auto-approve -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_DEV }} -var score_evaluation_container_image=${{ secrets.TETRIS_ECR_REPOSITORY_DEV }}
+        run: terraform apply -auto-approve -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_DEV }} -var tetris_ecr_repository=${{ secrets.TETRIS_ECR_REPOSITORY_DEV }}
         working-directory: ./terraform/environments/dev

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -29,6 +29,14 @@ jobs:
       - name: Terraform Init
         run: terraform init
         working-directory: ./terraform/environments/dev
+      
+      - name: Pip install for lambda layer 1
+        run: make
+        working-directory: ./scripts/api_to_dynamodb_lambda/layer
+
+      - name: Pip install for lambda layer 2
+        run: make
+        working-directory: ./scripts/api_to_sqs_lambda/layer
 
       - name: Terraform apply
         run: terraform apply -auto-approve -var tetris_frontend_origin=${{ secrets.TETRIS_FRONT_ORIGIN_DEV }} -var tetris_ecr_repository=${{ secrets.TETRIS_ECR_REPOSITORY_DEV }}

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -3,9 +3,8 @@ RUN apt-get update && apt-get install -y \
     xvfb
 ENV PYTHONUNBUFFERED 1
 ENV QT_QPA_PLATFORM offscreen
-RUN mkdir /app
-WORKDIR /app
-RUN git clone https://github.com/TetrisChallenge/tetris_score_server.git --depth 1 && pip install -r tetris_score_server/server/requirements.txt
-RUN mv /app/tetris_score_server/server /server
+RUN mkdir /server
 WORKDIR /server
-ENTRYPOINT make polling
+ADD ../server .
+RUN pip install -r requirements.txt
+ENTRYPOINT bash

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED 1
 ENV QT_QPA_PLATFORM offscreen
 RUN mkdir /app
 WORKDIR /app
-RUN git clone https://github.com/seigot/tetris_score_server.git --depth 1 && pip install -r tetris_score_server/server/requirements.txt
+RUN git clone https://github.com/TetrisChallenge/tetris_score_server.git --depth 1 && pip install -r tetris_score_server/server/requirements.txt
 RUN mv /app/tetris_score_server/server /server
 WORKDIR /server
 ENTRYPOINT make polling

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -7,4 +7,4 @@ RUN mkdir /server
 WORKDIR /server
 ADD ../server .
 RUN pip install -r requirements.txt
-ENTRYPOINT bash
+ENTRYPOINT make polling

--- a/scripts/api_to_dynamodb_lambda/layer/packages/requirements.txt
+++ b/scripts/api_to_dynamodb_lambda/layer/packages/requirements.txt
@@ -1,1 +1,1 @@
-protobuf==4.21.4
+protobuf==3.20.3

--- a/server/score_evaluation/infrastructure/dynamodb_infrastructure.py
+++ b/server/score_evaluation/infrastructure/dynamodb_infrastructure.py
@@ -7,7 +7,7 @@ from ..domain.repository.entry_test_result_repository import EntryTestResultRepo
 from ..domain.model.entity import Evaluation
 
 class EvaluationResultDynamoDBRepositoryInterface(EvaluationResultRepository):
-    def __init__(self, dynamodb_table_name=os.environ.get("dynamodb_table", "")):
+    def __init__(self, dynamodb_table_name=os.environ.get("DYNAMODB_TABLE")):
         self.dynamo = boto3.resource('dynamodb')
         self.table = self.dynamo.Table(dynamodb_table_name)      
     

--- a/server/score_evaluation/infrastructure/sqs_infrastructure.py
+++ b/server/score_evaluation/infrastructure/sqs_infrastructure.py
@@ -10,7 +10,7 @@ from ..domain.model.score_evaluation_message_pb2 import ScoreEvaluationMessage
 from ..domain.model.convert import protobuf_message_to_django_model
 
 class EvaluationMessageRepositoryInterface(EvaluationMessageRepository):
-    def __init__(self, sqs_url=os.environ.get("sqs-url", "")) -> None:
+    def __init__(self, sqs_url=os.environ.get("SQS_URL")) -> None:
         self.sqs = boto3.client('sqs', region_name='ap-northeast-1')
         self.sqs_url = sqs_url
         

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -28,3 +28,8 @@ variable "tetris_frontend_origin" {
     type = string
     sensitive = true
 }
+
+variable "score_evaluation_container_image"{
+  type = string
+  sensitive = true
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -22,6 +22,7 @@ module "resouces" {
   api_gateway_allow_origins = [
     var.tetris_frontend_origin,
   ]
+  score_evaluation_container_image = var.tetris_ecr_repository
 }
 
 variable "tetris_frontend_origin" {
@@ -29,7 +30,7 @@ variable "tetris_frontend_origin" {
     sensitive = true
 }
 
-variable "score_evaluation_container_image"{
+variable "tetris_ecr_repository"{
   type = string
   sensitive = true
 }

--- a/terraform/environments/prod/.terraform.lock.hcl
+++ b/terraform/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.3.0"
+  hashes = [
+    "h1:anS1fAU2IWUABjdscCF3nexOIeJXmC3bGOKyifatSDU=",
+    "zh:0869128d13abe12b297b0cd13b8767f10d6bf047f5afc4215615aabc39c2eb4f",
+    "zh:481ed837d63ba3aa45dd8736da83e911e3509dee0e7961bf5c00ed2644f807b3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9f08fe2977e2166849be24fb9f394e4d2697414d463f7996fd0d7beb4e19a29c",
+    "zh:9fe566deeafd460d27999ca0bbfd85426a5fcfcb40007b23884deb76da127b6f",
+    "zh:a1bd9a60925d9769e0da322e4523330ee86af9dc2e770cba1d0247a999ef29cb",
+    "zh:bb4094c8149f74308b22a87e1ac19bcccca76e8ef021b571074d9bccf1c0c6f0",
+    "zh:c8984c9def239041ce41ec8e19bbd76a49e74ed2024ff736dad60429dee89bcc",
+    "zh:ea4bb5ae73db1de3a586e62f39106f5e56770804a55aa5e6b4f642df973e0e75",
+    "zh:f44a9d596ecc3a8c5653f56ba0cd202ad93b49f76767f4608daf7260b813289e",
+    "zh:f5c5e6cc9f7f070020ab7d95fcc9ed8e20d5cf219978295a71236e22cbb6d508",
+    "zh:fd2273f51dcc8f43403bf1e425ba9db08a57c3ddcba5ad7a51742ccde21ca611",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.31.0"
+  constraints = "4.31.0"
+  hashes = [
+    "h1:KHxQC1OvJCzgnprfNZkygzK8tvzUVAFEitxeyC3DHao=",
+    "zh:14169119237a7ae174ea19f13edf34ed4de963ab97d937fee9d1f1ddd706f883",
+    "zh:24276942da2b858c2dd9eb0428cfd82b46e758fa00ae38685f05380f75034a8f",
+    "zh:378f1a9f603995bb76827b703ace8bf5212a9c7b96a106f4a87a9871249c885f",
+    "zh:38e992e1137d2e8dc203edd659432c21c87c7cbf99439b68253afdb82a079ead",
+    "zh:56ff847dd504d4098ff4ea7501c8d5ffae4e1ba0dacb85f658d992de474c8fec",
+    "zh:5b2ab38ba7d04e0d3c5bf0a0ab1aafe806faaa9be228480b772606bd32d41620",
+    "zh:6e6c6b10f05018691ef767efadc60fe3cd38adb2e66e65a74fa2be0ce3d7f49d",
+    "zh:90e9fb656d7c19cf702834d7da275b65fc40fbef10224f6f8295a40ca2acb43b",
+    "zh:92b5eaca47b3ab1829cf4cd96dc144f456bc023329f3e20cf3d5fdc913e6e5e3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ad782fb8ead528a0d8c7c77d1a417f4d8ceaaefbfc0a0c34993ba92e6dc5ff41",
+    "zh:b121595f53c85bdbb59504b255628d219c42586cb258f0d4cf8a532a98f766e5",
+  ]
+}

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -28,3 +28,8 @@ variable "tetris_frontend_origin" {
     type = string
     sensitive = true
 }
+
+variable "score_evaluation_container_image"{
+  type = string
+  sensitive = true
+}

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -22,6 +22,7 @@ module "resouces" {
   api_gateway_allow_origins = [
     var.tetris_frontend_origin,
   ]
+  score_evaluation_container_image = var.tetris_ecr_repository
 }
 
 variable "tetris_frontend_origin" {
@@ -29,7 +30,7 @@ variable "tetris_frontend_origin" {
     sensitive = true
 }
 
-variable "score_evaluation_container_image"{
+variable "tetris_ecr_repository"{
   type = string
   sensitive = true
 }

--- a/terraform/resouces/ecs.tf
+++ b/terraform/resouces/ecs.tf
@@ -79,11 +79,11 @@ resource "aws_ecs_task_definition" "score_evaluation_task" {
       memory = 2048
       environment = [
         {
-          "name" : "sqs_url",
+          "name" : "SQS_URL",
           "value" : data.aws_sqs_queue.score_evaluation_queue_data.url
         },
         {
-          "name" : "dynamodb_table",
+          "name" : "DYNAMODB_TABLE",
           "value" : var.dynamodb_table_name
         }
       ]

--- a/terraform/resouces/variables.tf
+++ b/terraform/resouces/variables.tf
@@ -163,7 +163,6 @@ variable "score_evaluation_ecs_task_definition_family" {
 }
 variable "score_evaluation_container_image" {
     type = string
-    default = "public.ecr.aws/r2u8u6o1/tetris_score_evaluation:latest"
 }
 variable "score_evaluation_ecs_task_execution_role_name" {
     type = string

--- a/terraform/resouces/vpc.tf
+++ b/terraform/resouces/vpc.tf
@@ -33,3 +33,8 @@ resource "aws_route_table" "vpc_route_table" {
     Name = var.score_evaluation_vpc_tag
   }
 }
+
+resource "aws_route_table_association" "ecs_subnet_route_table_association" {
+  subnet_id      = aws_subnet.tetris_score_server_subnet.id
+  route_table_id = aws_route_table.vpc_route_table.id
+}


### PR DESCRIPTION
- GitHub actionsの中でlambdaのlayerをpip installする部分を追加
- ecrのリポジトリ名は環境依存があるため、terraform コマンドの引数に追加させた
- ECSコンテナ内での環境変数を大文字+_で統一
- private subnetにルートテーブルをアタッチしてコンテナ内からインターネットに出ていけるようにする