### PR TITLE
評価開始時にstatusを更新する

### DIFF
--- a/server/score_evaluation/infrastructure/dynamodb_infrastructure.py
+++ b/server/score_evaluation/infrastructure/dynamodb_infrastructure.py
@@ -58,7 +58,7 @@ class EvaluationResultDynamoDBRepositoryInterface(EvaluationResultRepository):
             },
             UpdateExpression='set \
                 #StartedAt = :started_at, \
-                #Status = :status, \
+                #Status = :status \
                 ',
             ExpressionAttributeNames= {
                 '#StartedAt' : 'StartedAt',

--- a/server/score_evaluation/infrastructure/dynamodb_infrastructure.py
+++ b/server/score_evaluation/infrastructure/dynamodb_infrastructure.py
@@ -49,6 +49,27 @@ class EvaluationResultDynamoDBRepositoryInterface(EvaluationResultRepository):
             },
         )
         return response
+    
+    def update_started_at(self, evaluation: Evaluation):
+        response = self.table.update_item(
+            Key = {
+                "Id": evaluation.id,
+                "CreatedAt": evaluation.created_at
+            },
+            UpdateExpression='set \
+                #StartedAt = :started_at, \
+                #Status = :status, \
+                ',
+            ExpressionAttributeNames= {
+                '#StartedAt' : 'StartedAt',
+                '#Status' : 'Status',
+		    },
+            ExpressionAttributeValues={
+                ':started_at' : evaluation.started_at,
+                ':status' : evaluation.status,
+            },
+        )
+        return response
 
 class EntriesResultDynamoDBRepositoryInterface(EntryTestResultRepository):
     def __init__(self, dynamodb_table_name=os.environ.get("dynamodb_competition_table", "")):

--- a/server/score_evaluation/usecase/score_evaluation_usecase.py
+++ b/server/score_evaluation/usecase/score_evaluation_usecase.py
@@ -21,6 +21,11 @@ class ScoreEvaluationUsecase:
             eval_app = ScoreEvaluationApplication(_eval)
             print("start evaluation:\t", _eval)
             _eval.started_at = int(time())
+            _eval.status = "evaluating"
+            res = self.evaluation_dynamodb_repository_interface.update_started_at(_eval)
+            if res['ResponseMetadata']['HTTPStatusCode'] != 200:
+                print("failed update to dynamodb:\t", res)
+
             _eval = eval_app.evaluate(log_folder="/server/log")
             _eval.ended_at = int(time())
             print("finish evaluation:\t", _eval)


### PR DESCRIPTION
#70 で複数回実行時に評価に必要な時間が長くなった
あんまりにも長いと始まったかどうか不安になってくるので評価開始をdynamodbのステータスに更新することにした
