### PR TITLE
dynamodbの評価結果テーブルからレンジキーを削除

### DIFF
--- a/server/score_evaluation/infrastructure/dynamodb_infrastructure.py
+++ b/server/score_evaluation/infrastructure/dynamodb_infrastructure.py
@@ -14,8 +14,7 @@ class EvaluationResultDynamoDBRepositoryInterface(EvaluationResultRepository):
     def update(self, evaluation: Evaluation):
         response = self.table.update_item(
             Key = {
-                "Id": evaluation.id,
-                "CreatedAt": evaluation.created_at
+                "Id": evaluation.id
             },
             UpdateExpression='set \
                 #StartedAt = :started_at, \
@@ -71,8 +70,7 @@ class EvaluationResultDynamoDBRepositoryInterface(EvaluationResultRepository):
     def update_started_at(self, evaluation: Evaluation):
         response = self.table.update_item(
             Key = {
-                "Id": evaluation.id,
-                "CreatedAt": evaluation.created_at
+                "Id": evaluation.id
             },
             UpdateExpression='set \
                 #StartedAt = :started_at, \

--- a/terraform/resouces/dynamodb.tf
+++ b/terraform/resouces/dynamodb.tf
@@ -4,7 +4,6 @@ resource "aws_dynamodb_table" "dynamodb-table" {
   read_capacity  = 1
   write_capacity = 1
   hash_key       = "Id"
-  range_key      = "CreatedAt"
 
   attribute {
     name = "Id"


### PR DESCRIPTION
https://docs.aws.amazon.com/ja_jp/amazondynamodb/latest/developerguide/best-practices.html
ドキュメントを読んで設計を見なおし
dynamodbの全体計画は#86 を参照
- partitionキーをハッシュ値にしているので実質レンジキーは機能していないので、レンジキーから削除