### PR TITLE
評価結果詳細を取得するためのAPI作成とdynamodbのキーをIdのみに変更

### DIFF
--- a/server/score_evaluation/infrastructure/dynamodb_infrastructure.py
+++ b/server/score_evaluation/infrastructure/dynamodb_infrastructure.py
@@ -14,8 +14,7 @@ class EvaluationResultDynamoDBRepositoryInterface(EvaluationResultRepository):
     def update(self, evaluation: Evaluation):
         response = self.table.update_item(
             Key = {
-                "Id": evaluation.id,
-                "CreatedAt": evaluation.created_at
+                "Id": evaluation.id
             },
             UpdateExpression='set \
                 #StartedAt = :started_at, \
@@ -71,8 +70,7 @@ class EvaluationResultDynamoDBRepositoryInterface(EvaluationResultRepository):
     def update_started_at(self, evaluation: Evaluation):
         response = self.table.update_item(
             Key = {
-                "Id": evaluation.id,
-                "CreatedAt": evaluation.created_at
+                "Id": evaluation.id
             },
             UpdateExpression='set \
                 #StartedAt = :started_at, \

--- a/terraform/resouces/api_gateway.tf
+++ b/terraform/resouces/api_gateway.tf
@@ -22,12 +22,12 @@ resource "aws_apigatewayv2_stage" "tetris_api_stage" {
     throttling_rate_limit  = 10
     throttling_burst_limit = 10
   }
-  route_settings {
-    route_key              = "GET /result/{id}"
-    logging_level          = "ERROR"
-    throttling_rate_limit  = 10
-    throttling_burst_limit = 10
-  }
+  # route_settings {
+  #   route_key              = "GET /result/{id}"
+  #   logging_level          = "ERROR"
+  #   throttling_rate_limit  = 10
+  #   throttling_burst_limit = 10
+  # }
   route_settings {
     route_key              = "POST /entry"
     logging_level          = "ERROR"

--- a/terraform/resouces/api_gateway.tf
+++ b/terraform/resouces/api_gateway.tf
@@ -22,12 +22,12 @@ resource "aws_apigatewayv2_stage" "tetris_api_stage" {
     throttling_rate_limit  = 10
     throttling_burst_limit = 10
   }
-  # route_settings {
-  #   route_key              = "GET /result/{id}"
-  #   logging_level          = "ERROR"
-  #   throttling_rate_limit  = 10
-  #   throttling_burst_limit = 10
-  # }
+  route_settings {
+    route_key              = "GET /result/{id}"
+    logging_level          = "ERROR"
+    throttling_rate_limit  = 10
+    throttling_burst_limit = 10
+  }
   route_settings {
     route_key              = "POST /entry"
     logging_level          = "ERROR"
@@ -98,11 +98,11 @@ resource "aws_apigatewayv2_route" "get_results_from_dynamodb_route" {
   target    = "integrations/${aws_apigatewayv2_integration.get_results_from_dynamodb_lambda_integration.id}"
 }
 
-# resource "aws_apigatewayv2_route" "get_result_detail_from_dynamodb_route" {
-#   api_id    = aws_apigatewayv2_api.tetris_api.id
-#   route_key = "GET /result/{id}"
-#   target    = "integrations/${aws_apigatewayv2_integration.get_result_detail_from_dynamodb_lambda_integration.id}"
-# }
+resource "aws_apigatewayv2_route" "get_result_detail_from_dynamodb_route" {
+  api_id    = aws_apigatewayv2_api.tetris_api.id
+  route_key = "GET /result/{id}"
+  target    = "integrations/${aws_apigatewayv2_integration.get_result_detail_from_dynamodb_lambda_integration.id}"
+}
 
 resource "aws_apigatewayv2_route" "entry_competition_lambda" {
   api_id    = aws_apigatewayv2_api.tetris_api.id

--- a/terraform/resouces/api_gateway.tf
+++ b/terraform/resouces/api_gateway.tf
@@ -23,6 +23,12 @@ resource "aws_apigatewayv2_stage" "tetris_api_stage" {
     throttling_burst_limit = 10
   }
   route_settings {
+    route_key              = "GET /result/{id}"
+    logging_level          = "ERROR"
+    throttling_rate_limit  = 10
+    throttling_burst_limit = 10
+  }
+  route_settings {
     route_key              = "POST /entry"
     logging_level          = "ERROR"
     throttling_rate_limit  = 10
@@ -56,6 +62,14 @@ resource "aws_apigatewayv2_integration" "get_results_from_dynamodb_lambda_integr
   payload_format_version = "2.0"
 }
 
+resource "aws_apigatewayv2_integration" "get_result_detail_from_dynamodb_lambda_integration" {
+  api_id                 = aws_apigatewayv2_api.tetris_api.id
+  integration_uri        = aws_lambda_function.get_result_detail_from_dynamodb_function.invoke_arn
+  integration_type       = "AWS_PROXY"
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+}
+
 resource "aws_apigatewayv2_integration" "entry_competition_lambda_integration" {
   api_id                 = aws_apigatewayv2_api.tetris_api.id
   integration_uri        = aws_lambda_function.entry_competition_function.invoke_arn
@@ -83,6 +97,12 @@ resource "aws_apigatewayv2_route" "get_results_from_dynamodb_route" {
   route_key = "GET /results"
   target    = "integrations/${aws_apigatewayv2_integration.get_results_from_dynamodb_lambda_integration.id}"
 }
+
+# resource "aws_apigatewayv2_route" "get_result_detail_from_dynamodb_route" {
+#   api_id    = aws_apigatewayv2_api.tetris_api.id
+#   route_key = "GET /result/{id}"
+#   target    = "integrations/${aws_apigatewayv2_integration.get_result_detail_from_dynamodb_lambda_integration.id}"
+# }
 
 resource "aws_apigatewayv2_route" "entry_competition_lambda" {
   api_id    = aws_apigatewayv2_api.tetris_api.id

--- a/terraform/resouces/api_to_dynamodb_lambda.tf
+++ b/terraform/resouces/api_to_dynamodb_lambda.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "get_result_from_dynamodb_assume_role" {
 
 data "aws_iam_policy_document" "get_result_from_dynamodb_policy_doc" {
   statement {
-    actions = ["dynamodb:Scan", "dynamodb: GetItem"]
+    actions = ["dynamodb:Scan", "dynamodb:GetItem"]
     resources = [
       aws_dynamodb_table.dynamodb-table.arn,
       aws_dynamodb_table.dynamodb-competition-table.arn

--- a/terraform/resouces/api_to_dynamodb_lambda.tf
+++ b/terraform/resouces/api_to_dynamodb_lambda.tf
@@ -109,7 +109,7 @@ resource "aws_lambda_permission" "api_to_dynamodb_permission" {
 resource "aws_lambda_permission" "get_result_detail_from_dynamodb_permission" {
   statement_id  = "AllowExecutionFromAPIGateway"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.get_result_detail_function.function_name
+  function_name = aws_lambda_function.get_result_detail_from_dynamodb_function.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.tetris_api.execution_arn}/*/GET/result/*"
 }

--- a/terraform/resouces/api_to_dynamodb_lambda.tf
+++ b/terraform/resouces/api_to_dynamodb_lambda.tf
@@ -60,7 +60,7 @@ resource "aws_lambda_function" "get_result_from_dynamodb_function" {
   layers           = ["${aws_lambda_layer_version.api_to_dynamodb_lambda_layer.arn}"]
 }
 
-resource "aws_lambda_function" "get_result_detail_function" {
+resource "aws_lambda_function" "get_result_detail_from_dynamodb_function" {
   function_name = var.get_result_detail_lambda_name
   handler       = var.get_result_detail_lambda_handler
   role          = aws_iam_role.get_result_from_dynamodb_lambda_role.arn
@@ -104,6 +104,14 @@ resource "aws_lambda_permission" "api_to_dynamodb_permission" {
   function_name = aws_lambda_function.get_result_from_dynamodb_function.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.tetris_api.execution_arn}/*/GET/results"
+}
+
+resource "aws_lambda_permission" "get_result_detail_from_dynamodb_permission" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.get_result_detail_function.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.tetris_api.execution_arn}/*/GET/result/*"
 }
 
 resource "aws_lambda_permission" "get_entries_from_dynamodb_lambda_permission" {

--- a/terraform/resouces/api_to_dynamodb_lambda.tf
+++ b/terraform/resouces/api_to_dynamodb_lambda.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "get_result_from_dynamodb_assume_role" {
 
 data "aws_iam_policy_document" "get_result_from_dynamodb_policy_doc" {
   statement {
-    actions = ["dynamodb:Scan"]
+    actions = ["dynamodb:Scan", "dynamodb: GetItem"]
     resources = [
       aws_dynamodb_table.dynamodb-table.arn,
       aws_dynamodb_table.dynamodb-competition-table.arn
@@ -48,6 +48,21 @@ resource "aws_iam_role_policy_attachment" "get_result_from_dynamodb_attachment" 
 resource "aws_lambda_function" "get_result_from_dynamodb_function" {
   function_name = var.get_evaluation_results_lambda_name
   handler       = var.get_evaluation_results_lambda_handler
+  role          = aws_iam_role.get_result_from_dynamodb_lambda_role.arn
+  runtime       = "python3.9"
+  environment {
+    variables = {
+      dynamodb_table_name = var.dynamodb_table_name
+    }
+  }
+  filename         = data.archive_file.api_to_dynamodb_function_source.output_path
+  source_code_hash = data.archive_file.api_to_dynamodb_function_source.output_base64sha256
+  layers           = ["${aws_lambda_layer_version.api_to_dynamodb_lambda_layer.arn}"]
+}
+
+resource "aws_lambda_function" "get_result_detail_function" {
+  function_name = var.get_result_detail_lambda_name
+  handler       = var.get_result_detail_lambda_handler
   role          = aws_iam_role.get_result_from_dynamodb_lambda_role.arn
   runtime       = "python3.9"
   environment {

--- a/terraform/resouces/dynamodb.tf
+++ b/terraform/resouces/dynamodb.tf
@@ -4,7 +4,6 @@ resource "aws_dynamodb_table" "dynamodb-table" {
   read_capacity  = 1
   write_capacity = 1
   hash_key       = "Id"
-  range_key      = "CreatedAt"
 
   attribute {
     name = "Id"

--- a/terraform/resouces/variables.tf
+++ b/terraform/resouces/variables.tf
@@ -77,11 +77,11 @@ variable "get_evaluation_results_lambda_handler" {
 }
 variable "get_result_detail_lambda_name" {
     type = string
-    default = "get_result_detail_lambda"
+    default = "get_result_detail_from_dynamodb_lambda"
 }
 variable "get_result_detail_lambda_handler" {
     type = string
-    default = "get_result_from_dynamodb.get_result_detail"
+    default = "get_result_detail_from_dynamodb.get_result_detail"
 }
 variable "get_competition_entries_lambda_name" {
     type = string

--- a/terraform/resouces/variables.tf
+++ b/terraform/resouces/variables.tf
@@ -81,7 +81,7 @@ variable "get_result_detail_lambda_name" {
 }
 variable "get_result_detail_lambda_handler" {
     type = string
-    default = "get_result_detail_from_dynamodb.get_result_detail"
+    default = "get_result_from_dynamodb.get_result_detail"
 }
 variable "get_competition_entries_lambda_name" {
     type = string

--- a/terraform/resouces/variables.tf
+++ b/terraform/resouces/variables.tf
@@ -75,6 +75,14 @@ variable "get_evaluation_results_lambda_handler" {
     type = string
     default = "get_result_from_dynamodb.lambda_handler"
 }
+variable "get_result_detail_lambda_name" {
+    type = string
+    default = "get_result_detail_lambda"
+}
+variable "get_result_detail_lambda_handler" {
+    type = string
+    default = "get_result_from_dynamodb.get_result_detail"
+}
 variable "get_competition_entries_lambda_name" {
     type = string
     default = "get_competition_entries_lambda"

--- a/terraform/scripts/api_to_dynamodb_lambda/src/get_result_from_dynamodb.py
+++ b/terraform/scripts/api_to_dynamodb_lambda/src/get_result_from_dynamodb.py
@@ -8,7 +8,7 @@ def lambda_handler(event: dict, context):
     table = dynamodb.Table(table_name)
     try:
         response = table.scan(
-            Limit=30,  
+            Limit=200,  
         )
     except Exception as e:
         response = {
@@ -28,7 +28,6 @@ def get_result_detail(event: dict, context):
         response = table.get_item(
             Key={
                 'Id': event["body"]["id"],
-                "CreatedAt": event["body"]["created_at"],
             }
         )
     except Exception as e:

--- a/terraform/scripts/api_to_dynamodb_lambda/src/get_result_from_dynamodb.py
+++ b/terraform/scripts/api_to_dynamodb_lambda/src/get_result_from_dynamodb.py
@@ -27,7 +27,7 @@ def get_result_detail(event: dict, context):
     try:
         response = table.get_item(
             Key={
-                'Id': event["body"]["id"],
+                'Id': event['pathParameters']['id'],
             }
         )
     except Exception as e:

--- a/terraform/scripts/api_to_dynamodb_lambda/src/get_result_from_dynamodb.py
+++ b/terraform/scripts/api_to_dynamodb_lambda/src/get_result_from_dynamodb.py
@@ -20,3 +20,24 @@ def lambda_handler(event: dict, context):
             "code": 501
         }
     return response
+
+def get_result_detail(event: dict, context):
+    dynamodb = boto3.resource("dynamodb")
+    table = dynamodb.Table(table_name)
+    try:
+        response = table.get_item(
+            Key={
+                'Id': event["body"]["id"],
+                "CreatedAt": event["body"]["created_at"],
+            }
+        )
+    except Exception as e:
+        response = {
+            "error": {
+                "message": "failed to scan dynamodb: " + str(e),
+                "body": event,
+                "type": "dynamodb access exception",
+            },
+            "code": 501
+        }
+    return response


### PR DESCRIPTION
#85 #88 
- dynamodbのキーをidのみとして、idのみで検索が可能に変更する
- {API_URL}/result/{id}で`id`をキーとして詳細結果をlambdaで検索して出力する
